### PR TITLE
Implement credit type multiplier calculation in both scoring functions

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -544,6 +544,9 @@ model PotentialCPLSavings {
   NonMilitaryCredits  Float
   MilitaryStudents    Int
   NonMilitaryStudents Int
+  ElectiveCredits     Float
+  AreaCredits         Float
+  CourseCredits       Float
    @@id([Sorder, CollegeID])
   @@map("_PotentialCPLSavings")
 }

--- a/src/components/features/chancelor/PotentialSavingsTable.tsx
+++ b/src/components/features/chancelor/PotentialSavingsTable.tsx
@@ -78,6 +78,10 @@ export const PotentialSavingsTable = ({
         Students: item.Students,
         AvgUnits: item.AverageUnits,
         Units: item.Units,
+        ElectiveCredits: item.ElectiveCredits,
+        AreaCredits: item.AreaCredits,
+        CourseCredits: item.CourseCredits,
+
       }));
   }, [data]);
 


### PR DESCRIPTION
Apply multiplier only to the avgUnitScore component (not the entire score) Use aggressive elective credit penalty (-60%
Update penalty display logic to show multiplier effect UI/UX Updates:
Update tooltip content to include credit type information Ensure penalties section shows credit type penalties with appropriate explanations Consider truncating college names that are too long in the chart (>15 characters)